### PR TITLE
fix CF error on alias storages.

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -1,2 +1,3 @@
 export const ADDRESS = "YOUR_ADDRESS";
 export const TOKEN = "YOUR_TOKEN";
+export const WORKER_ADDRESS = "YOUR_WORKER_ADDRESS";

--- a/src/handleRequest.ts
+++ b/src/handleRequest.ts
@@ -1,0 +1,9 @@
+import { handleDownload } from "./handleDownload";
+import { handleOptions } from "./handleOptions";
+
+export async function handleRequest(request: Request) {
+    if (request.method === "OPTIONS") {
+        return handleOptions(request);
+    }
+    return await handleDownload(request);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { handleDownload } from "./handleDownload";
-import { handleOptions } from "./handleOptions";
+import { handleRequest } from "./handleRequest";
 
 export interface Env {
   // Example binding to KV. Learn more at https://developers.cloudflare.com/workers/runtime-apis/kv/
@@ -18,9 +17,6 @@ export default {
     env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
-    if (request.method === "OPTIONS") {
-      return handleOptions(request);
-    }
-    return handleDownload(request);
+    return await handleRequest(request);
   },
 };


### PR DESCRIPTION
Enabling proxy on both of the alias and real storages is causing errors like too many redirects or SSL handshake failed 525 when trying to download